### PR TITLE
Add coverage to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,3 +30,9 @@ jobs:
           name: Test
           command: |
             go test -v ./...
+      - run:
+          name: Coverage
+          command: |
+              go test -cover -coverprofile=coverage.txt
+              go get github.com/mattn/goveralls
+              goveralls -service=circleci -coverprofile=coverage.txt -repotoken=$COVERALLS_REPO_TOKEN


### PR DESCRIPTION
Add coverage job to circleci configuration that uploads the coverage profile to coveralls. 

Resolves #4 